### PR TITLE
[UPDATE] Added support for array of strings

### DIFF
--- a/projects/devon4ng/cache/README.md
+++ b/projects/devon4ng/cache/README.md
@@ -31,7 +31,22 @@ Import and configure it in the `@NgModule` imports section:
     ...otherModules,
     CacheModule.forRoot({
       maxCacheAge: 1800000, // number
-      urlRegExp: new RegExp('http', 'g').toString(); // RegExp object or string
+      urlRegExp: new RegExp('http.*', 'g').toString(); // RegExp object or string
+    }),
+  ]
+})
+```
+
+In case you need to define a list of strings instead, you can do the following:
+
+```typescript
+@NgModule({
+  ...
+  imports: [
+    ...otherModules,
+    CacheModule.forRoot({
+      maxCacheAge: 1800000, // number
+      urlRegExp: ['data', 'users']; // strings array
     }),
   ]
 })
@@ -40,6 +55,6 @@ Import and configure it in the `@NgModule` imports section:
 The configuration object defines the following two parameters:
 
 - `maxCacheAge`: Age in milliseconds. After that the cache entry will be developed. By default `1800000` or 30 minutes.
-- `urlRegExp`: Regular expression as `string` or `RegExp` object that defines which URLs are going to be cached. By default any URL that contains `http`, that is **all the URLs**.
+- `urlRegExp`: Regular expression as `string`, `string[]` or `RegExp` object that defines which URLs are going to be cached. By default any URL that contains `http`, that is **all the URLs**.
 
 Both parameters are optional, so you could set up only one.

--- a/projects/devon4ng/cache/package.json
+++ b/projects/devon4ng/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devon4ng/cache",
-  "version": "0.0.12",
+  "version": "0.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/devonfw/devon4ng-library.git"

--- a/projects/devon4ng/cache/src/lib/cache.service.ts
+++ b/projects/devon4ng/cache/src/lib/cache.service.ts
@@ -11,7 +11,7 @@ const Hash: any = require('object-hash');
 })
 export class CacheService implements Cache {
   cacheMap = new Map<string, CacheEntry>();
-  urlRegExp: string | RegExp;
+  urlRegExp: string | string[] | RegExp;
   maxCacheAge: number;
 
   constructor(@Optional() config: CacheServiceConfig) {

--- a/projects/devon4ng/cache/src/lib/interceptor/cache-interceptor.service.ts
+++ b/projects/devon4ng/cache/src/lib/interceptor/cache-interceptor.service.ts
@@ -41,11 +41,18 @@ export class CacheInterceptorService implements HttpInterceptor {
   }
 
   private isRequestCachable(req: HttpRequest<any>): boolean {
-    return (
-      req.method !== 'DELETE' &&
-      (req.url.match(this.cache.urlRegExp)
-        ? req.url.match(this.cache.urlRegExp).length > 0
-        : false)
-    );
+    if (Array.isArray(this.cache.urlRegExp)) {
+      return (
+        req.method !== 'DELETE' &&
+        this.cache.urlRegExp.some((item) => req.url.indexOf(item) > -1)
+      );
+    } else {
+      return (
+        req.method !== 'DELETE' &&
+        (req.url.match(this.cache.urlRegExp)
+          ? req.url.match(this.cache.urlRegExp).length > 0
+          : false)
+      );
+    }
   }
 }

--- a/projects/devon4ng/cache/src/lib/models/cache-config.class.ts
+++ b/projects/devon4ng/cache/src/lib/models/cache-config.class.ts
@@ -5,5 +5,5 @@
  */
 export class CacheServiceConfig {
   maxCacheAge ? = 1800000;
-  urlRegExp?: string | RegExp = new RegExp('http.*', 'g').toString();
+  urlRegExp?: string | string[] | RegExp = new RegExp('http.*', 'g').toString();
 }


### PR DESCRIPTION
As there are issues with AOT compilation for RegExp, I have included support for strings array to check if the URL is cacheable. For example, the usage will be in this case:

```typescript
@NgModule({
  ...
  imports: [
    ...otherModules,
    CacheModule.forRoot({
      maxCacheAge: 1800000, // number
      urlRegExp: ['data', 'users']; // strings array
    }),
  ]
})
```